### PR TITLE
Add environments for building Packer images and testing by deploying a Slurm cluster

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @stackhpc/batch

--- a/cluster_extra_vars.yml
+++ b/cluster_extra_vars.yml
@@ -1,0 +1,33 @@
+---
+
+# Extra vars needed to build cluster
+cluster_terraform_template_dir: "{{ playbook_dir }}/cluster_terraform_template"
+
+# Cluster instance vars
+cluster_name: "slurm"
+cluster_id: "{{ cluster_name }}"
+openhpc_slurm_partitions:
+  - name: "m"
+    count: 1
+    flavor_name: "g.4.standard"
+    default: "YES"
+  - name: "s"
+    count: 2
+    flavor_name: "g.2.standard"
+    default: "NO"
+cluster_run_validation: true
+cluster_user_ssh_public_key: ""
+home_volume_size: 50
+
+# Cloud vars
+cluster_image: 94b50280-7c4a-4f36-ba2b-1f95c56bdde1
+cluster_external_network: "Internet"
+cluster_cidr: "192.168.99.0/24" # Can have many project networks with the same CIDR
+cluster_nameservers:
+  - 1.1.1.1
+  - 8.8.8.8
+login_flavor_name: "g.4.standard"
+control_flavor_name: "g.4.standard"
+metrics_db_maximum_size: 5
+block_device_prefix: "sd"
+

--- a/cluster_terraform_template/outputs.tf.j2
+++ b/cluster_terraform_template/outputs.tf.j2
@@ -1,0 +1,50 @@
+output "cluster_gateway_ip" {
+  description = "The IP address of the gateway used to contact the cluster nodes"
+  value       = openstack_networking_floatingip_v2.cluster_floating_ip.address
+}
+
+output "cluster_ssh_private_key" {
+  description = "The private key used to deploy the cluster"
+  value = openstack_compute_keypair_v2.cluster_keypair.private_key
+}
+
+output "cluster_nodes" {
+  description = "A list of the nodes in the cluster from which an Ansible inventory will be populated"
+  value       = concat(
+    [
+      {
+        name          = openstack_compute_instance_v2.login.name
+        ip            = openstack_compute_instance_v2.login.network[0].fixed_ip_v4
+        groups        = ["{{ cluster_name }}_login"],
+        facts  = {
+          openstack_project_id = data.openstack_identity_auth_scope_v3.scope.project_id
+        }
+      },
+      {
+        name          = openstack_compute_instance_v2.control.name
+        ip            = openstack_compute_instance_v2.control.network[0].fixed_ip_v4
+        groups        = ["{{ cluster_name }}_control"],
+        facts  = {
+          openstack_project_id = data.openstack_identity_auth_scope_v3.scope.project_id
+        }
+      }
+    ],
+    {% for partition in openhpc_slurm_partitions %}
+    [
+      for compute in openstack_compute_instance_v2.{{ partition.name }}: {
+        name          = compute.name
+        ip            = compute.network[0].fixed_ip_v4
+        groups        = ["{{ cluster_name }}_compute", "{{ cluster_name }}_{{ partition.name }}"],
+        facts  = {
+          openstack_project_id = data.openstack_identity_auth_scope_v3.scope.project_id
+        }
+      }
+    ]{{ ',' if not loop.last }}
+    {% endfor %}
+  )
+}
+
+output "cluster_image" {
+  description = "The id of the image used to build the cluster nodes"
+  value       = "{{ cluster_previous_image | default(cluster_image) }}"
+}

--- a/cluster_terraform_template/providers.tf.j2
+++ b/cluster_terraform_template/providers.tf.j2
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.14"
+
+  # We need the OpenStack provider
+  required_providers {
+    openstack = {
+      source = "terraform-provider-openstack/openstack"
+    }
+  }
+}

--- a/cluster_terraform_template/resources.tf.j2
+++ b/cluster_terraform_template/resources.tf.j2
@@ -1,0 +1,267 @@
+#####
+##### The identity scope we are operating in
+##### Used to output the OpenStack project ID as a fact for provisioned hosts
+#####
+data "openstack_identity_auth_scope_v3" "scope" {
+  name = "{{ cluster_name }}"
+}
+
+#####
+##### Security groups for the cluster
+#####
+
+# Security group to hold common rules for the cluster
+resource "openstack_networking_secgroup_v2" "secgroup_slurm_cluster" {
+  name                 = "{{ cluster_name }}-secgroup-slurm-cluster"
+  description          = "Rules for the slurm cluster nodes"
+  delete_default_rules = true   # Fully manage with terraform
+}
+
+# Security group to hold specific rules for the login node
+resource "openstack_networking_secgroup_v2" "secgroup_slurm_login" {
+  name                 = "{{ cluster_name }}-secgroup-slurm-login"
+  description          = "Specific rules for the slurm login node"
+  delete_default_rules = true   # Fully manage with terraform
+}
+
+## Allow all egress for all cluster nodes
+resource "openstack_networking_secgroup_rule_v2" "secgroup_slurm_cluster_rule_egress_v4" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup_slurm_cluster.id}"
+}
+
+## Allow all ingress between nodes in the cluster
+resource "openstack_networking_secgroup_rule_v2" "secgroup_slurm_cluster_rule_ingress_internal_v4" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  remote_group_id   = "${openstack_networking_secgroup_v2.secgroup_slurm_cluster.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup_slurm_cluster.id}"
+}
+
+## Allow ingress on port 22 (SSH) from anywhere for the login nodes
+resource "openstack_networking_secgroup_rule_v2" "secgroup_slurm_login_rule_ingress_ssh_v4" {
+  direction = "ingress"
+  ethertype = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup_slurm_login.id}"
+}
+
+## Allow ingress on port 443 (HTTPS) from anywhere for the login nodes
+resource "openstack_networking_secgroup_rule_v2" "secgroup_slurm_login_rule_ingress_https_v4" {
+  direction = "ingress"
+  ethertype = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 443
+  port_range_max    = 443
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup_slurm_login.id}"
+}
+
+## Allow ingress on port 80 (HTTP) from anywhere for the login nodes
+resource "openstack_networking_secgroup_rule_v2" "secgroup_slurm_login_rule_ingress_http_v4" {
+  direction = "ingress"
+  ethertype = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 80
+  port_range_max    = 80
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup_slurm_login.id}"
+}
+
+#####
+##### Volumes
+#####
+resource "openstack_blockstorage_volume_v3" "state" {
+    name = "{{ cluster_name }}-state"
+    description = "State for control node"
+    size = "{{ state_volume_size }}"
+}
+
+resource "openstack_blockstorage_volume_v3" "home" {
+    name = "{{ cluster_name }}-home"
+    description = "Home for control node"
+    size = "{{ home_volume_size }}"
+    {% if use_home_volume_type_fast is defined and use_home_volume_type_fast %}
+    {% if home_volume_type_fast is defined %}
+    volume_type = "{{ home_volume_type_fast }}"
+    {% endif %}
+    {% endif %}
+}
+
+#####
+###### Cluster network
+######
+
+data "openstack_networking_network_v2" "cluster_external_network" {
+  name = "{{ cluster_external_network }}"
+}
+
+resource "openstack_networking_network_v2" "cluster_network" {
+  name           = "{{ cluster_name }}-net"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "cluster_subnet" {
+  name       = "{{ cluster_name }}-subnet"
+  network_id = "${openstack_networking_network_v2.cluster_network.id}"
+  cidr       = "{{ cluster_cidr }}"
+  {% if cluster_nameservers %}
+  dns_nameservers = [
+  {% for nameserver in cluster_nameservers %}
+    "{{ nameserver }}"{{ ',' if not loop.last }}
+  {% endfor %}
+  ]
+  {% endif %}
+  ip_version = 4
+}
+
+resource "openstack_networking_router_v2" "cluster_router" {
+  name                = "{{ cluster_name }}-router"
+  admin_state_up      = true
+  external_network_id = "${data.openstack_networking_network_v2.cluster_external_network.id}"
+}
+
+resource "openstack_networking_router_interface_v2" "cluster_router_interface" {
+  router_id = "${openstack_networking_router_v2.cluster_router.id}"
+  subnet_id = "${openstack_networking_subnet_v2.cluster_subnet.id}"
+}
+
+#####
+###### Cluster private key
+######
+
+resource "openstack_compute_keypair_v2" "cluster_keypair" {
+  name = "{{ cluster_name }}-deploy-key"
+}
+
+#####
+##### Cluster nodes
+#####
+
+resource "openstack_compute_instance_v2" "login" {
+  name      = "{{ cluster_name }}-login-0"
+  image_id  = "{{ cluster_previous_image | default(cluster_image) }}"
+  {% if login_flavor_name is defined %}
+  flavor_name = "{{ login_flavor_name }}"
+  {% else %}
+  flavor_id = "{{ login_flavor }}"
+  {% endif %}
+
+  network {
+    uuid = "${openstack_networking_subnet_v2.cluster_subnet.network_id}"
+  }
+
+  security_groups = [
+    "${openstack_networking_secgroup_v2.secgroup_slurm_cluster.name}",
+    "${openstack_networking_secgroup_v2.secgroup_slurm_login.name}"
+  ]
+  # Use cloud-init to inject the SSH keys
+  user_data = <<-EOF
+    #cloud-config
+    ssh_authorized_keys:
+      - "${openstack_compute_keypair_v2.cluster_keypair.public_key}"
+      - {{ cluster_user_ssh_public_key }}
+  EOF
+}
+
+resource "openstack_compute_instance_v2" "control" {
+  name      = "{{ cluster_name }}-control-0"
+  image_id  = "{{ cluster_previous_image | default(cluster_image) }}"
+  {% if control_flavor_name is defined %}
+  flavor_name = "{{ control_flavor_name }}"
+  {% else %}
+  flavor_id = "{{ control_flavor }}"
+  {% endif %}
+
+  network {
+    uuid = "${openstack_networking_subnet_v2.cluster_subnet.network_id}"
+  }
+
+  security_groups = ["${openstack_networking_secgroup_v2.secgroup_slurm_cluster.name}"]
+
+  # root device:
+  block_device {
+      uuid = "{{ cluster_previous_image | default(cluster_image) }}"
+      source_type  = "image"
+      destination_type = "local"
+      boot_index = 0
+      delete_on_termination = true
+  }
+
+  # state volume:
+  block_device {
+      destination_type = "volume"
+      source_type  = "volume"
+      boot_index = -1
+      uuid = openstack_blockstorage_volume_v3.state.id
+  }
+
+  # home volume:
+  block_device {
+      destination_type = "volume"
+      source_type  = "volume"
+      boot_index = -1
+      uuid = openstack_blockstorage_volume_v3.home.id
+  }
+
+  # Use cloud-init to a) inject SSH keys b) configure volumes
+  user_data = <<-EOF
+    #cloud-config
+    ssh_authorized_keys:
+      - "${openstack_compute_keypair_v2.cluster_keypair.public_key}"
+      - {{ cluster_user_ssh_public_key }}
+    fs_setup:
+      - label: state
+        filesystem: ext4
+        device: /dev/{{ block_device_prefix }}b
+        partition: auto
+      - label: home
+        filesystem: ext4
+        device: /dev/{{ block_device_prefix }}c
+        partition: auto
+    mounts:
+        - [LABEL=state, /var/lib/state, auto, "x-systemd.required-by=nfs-server.service,x-systemd.before=nfs-server.service"]
+        - [LABEL=home, /exports/home, auto, "x-systemd.required-by=nfs-server.service,x-systemd.before=nfs-server.service"]
+  EOF
+}
+
+{% for partition in openhpc_slurm_partitions %} 
+resource "openstack_compute_instance_v2" "{{ partition.name }}" {
+  count = {{ partition.count }}
+
+  name      = "{{ cluster_name }}-compute-{{ partition.name }}-${count.index}"
+  image_id  = "{{ cluster_previous_image | default(cluster_image) }}"
+  flavor_name = "{{ partition.flavor_name }}"
+
+  network {
+    uuid = "${openstack_networking_subnet_v2.cluster_subnet.network_id}"
+  }
+
+  security_groups = ["${openstack_networking_secgroup_v2.secgroup_slurm_cluster.name}"]
+  # Use cloud-init to inject the SSH keys
+  user_data = <<-EOF
+    #cloud-config
+    ssh_authorized_keys:
+      - "${openstack_compute_keypair_v2.cluster_keypair.public_key}"
+      - {{ cluster_user_ssh_public_key }}
+  EOF
+}
+{% endfor %}
+#####
+##### Floating IP association for login node
+#####
+data "openstack_networking_subnet_ids_v2" "ext_subnets" {
+  network_id = "${data.openstack_networking_network_v2.cluster_external_network.id}"
+}
+
+resource "openstack_networking_floatingip_v2" "cluster_floating_ip" {
+  pool       = "${data.openstack_networking_network_v2.cluster_external_network.name}"
+  subnet_ids = "${data.openstack_networking_subnet_ids_v2.ext_subnets.ids}"
+}
+
+resource "openstack_compute_floatingip_associate_v2" "login_floatingip_assoc" {
+  floating_ip = "${openstack_networking_floatingip_v2.cluster_floating_ip.address}"
+  instance_id = "${openstack_compute_instance_v2.login.id}"
+}
+

--- a/environments/NL1-CI/README.md
+++ b/environments/NL1-CI/README.md
@@ -1,0 +1,17 @@
+# NL1-CI cluster
+
+Intended to be driven with CI tooling test images created using the eschercloud-image-build environment.
+
+Update the `cluster_image` variable in `cluster_extra_vars.yml` with an updated image UUID from
+eschercloud-image-build/packer/packer-manifest.json, then deploy a cluster like this:
+
+```
+source NL1-CI/activate
+export OS_CLOUD=openstack
+
+# Configure
+ansible-playbook -e ${APPLIANCES_ENVIRONMENT_ROOT}/cluster_extra_vars.yml ${APPLIANCES_ENVIRONMENT_ROOT}/../../slurm-infra.yml
+
+# Tear down
+ansible-playbook -e ${APPLIANCES_ENVIRONMENT_ROOT}/cluster_extra_vars.yml -e cluster_state=absent ${APPLIANCES_ENVIRONMENT_ROOT}/../../slurm-infra.yml
+```

--- a/environments/NL1-CI/activate
+++ b/environments/NL1-CI/activate
@@ -1,0 +1,24 @@
+export APPLIANCES_ENVIRONMENT_ROOT=$(dirname $(realpath ${BASH_SOURCE[0]:-${(%):-%x}}))
+echo "Setting APPLIANCES_ENVIRONMENT_ROOT to $APPLIANCES_ENVIRONMENT_ROOT"
+
+APPLIANCES_ENVIRONMENT_NAME=$(basename $APPLIANCES_ENVIRONMENT_ROOT)
+export PS1="${APPLIANCES_ENVIRONMENT_NAME}/ ${PS1}"
+
+export APPLIANCES_REPO_ROOT=$(realpath "$APPLIANCES_ENVIRONMENT_ROOT/../../vendor/stackhpc/ansible-slurm-appliance")
+echo "Setting APPLIANCES_REPO_ROOT to $APPLIANCES_REPO_ROOT"
+
+export TF_VAR_environment_root=$(realpath "$APPLIANCES_ENVIRONMENT_ROOT")
+echo "Setting TF_VAR_environment_root to $TF_VAR_environment_root"
+
+export PKR_VAR_environment_root=$(realpath "$APPLIANCES_ENVIRONMENT_ROOT")
+echo "Setting PKR_VAR_environment_root to $PKR_VAR_environment_root"
+
+export PKR_VAR_repo_root=$(realpath "$APPLIANCES_REPO_ROOT")
+echo "Setting PKR_VAR_repo_root to $PKR_VAR_repo_root"
+
+if [ -f "$APPLIANCES_ENVIRONMENT_ROOT/ansible.cfg" ]; then
+   export ANSIBLE_CONFIG=$APPLIANCES_ENVIRONMENT_ROOT/ansible.cfg
+   echo "Setting ANSIBLE_CONFIG to $ANSIBLE_CONFIG"
+fi
+
+

--- a/environments/NL1-CI/ansible.cfg
+++ b/environments/NL1-CI/ansible.cfg
@@ -1,0 +1,17 @@
+[defaults]
+any_errors_fatal = True
+stdout_callback = debug
+stderr_callback = debug
+gathering = smart
+forks = 30
+host_key_checking = False
+inventory = inventory,../../vendor/stackhpc/ansible-slurm-appliance/environments/common/inventory
+collections_path = ../../ansible/collections
+filter_plugins = ../../ansible/filter_plugins:../../vendor/stackhpc/ansible-slurm-appliance/ansible/filter_plugins
+default_vars_plugin_path = ../../vars_plugins
+vars_plugins_enabled = host_group_vars,cwd_host_group_vars
+roles_path = ../../vendor/stackhpc/ansible-slurm-appliance/ansible/roles:../../roles
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=240s -o PreferredAuthentications=publickey -o UserKnownHostsFile=/dev/null
+pipelining = True

--- a/environments/NL1-CI/cluster_extra_vars.yml
+++ b/environments/NL1-CI/cluster_extra_vars.yml
@@ -1,0 +1,44 @@
+---
+
+appliances_environment_root: "{{ lookup('env', 'APPLIANCES_ENVIRONMENT_ROOT') }}"
+
+# Extra vars needed to build cluster
+cluster_terraform_template_dir: "{{ appliances_environment_root }}/cluster_terraform_template"
+
+# Something not right about NL1's object storage 
+#terraform_backend_type: swift
+#terraform_backend_config:
+#  container: "{{ cluster_name }}-terraform-state"
+
+# Cluster instance vars
+cluster_name: "slurm"
+cluster_id: "{{ cluster_name }}"
+openhpc_slurm_partitions:
+  - name: "m"
+    count: 1
+    flavor_name: "g.4.standard"
+    default: "YES"
+  - name: "s"
+    count: 2
+    flavor_name: "g.2.standard"
+    default: "NO"
+cluster_run_validation: true
+cluster_user_ssh_public_keys: 
+  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJg3W6wKjLrKObikQz84K3oZJjUDpp2c6k62ZE4x1fev matta@stackhpc.com"
+  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBL0TOpOWI9bn2JMuwxmjuM/z3aDYu7fDQk68p+Wafe3 a.cleave@eshchercloud.ai"
+  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILsBdBzq1y4Vtr1FTJvF557t/Tvn+ZOSx5HouJ89B9rm david@macbookpro"
+  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKGHDwDB7Z7JQ/Sr9VZlnoAjzJOdNZQIE8vxRW//rK1h mouza"
+home_volume_size: 50
+
+# Cloud vars
+cluster_image: bc284ba2-6abb-4bca-9274-0eaed2db751b
+cluster_external_network: "Internet"
+cluster_cidr: "192.168.99.0/24" # Can have many project networks with the same CIDR
+cluster_nameservers:
+  - 1.1.1.1
+  - 8.8.8.8
+login_flavor_name: "g.4.standard"
+control_flavor_name: "g.4.standard"
+metrics_db_maximum_size: 5
+block_device_prefix: "sd"
+

--- a/environments/NL1-CI/cluster_terraform_template/outputs.tf.j2
+++ b/environments/NL1-CI/cluster_terraform_template/outputs.tf.j2
@@ -1,0 +1,50 @@
+output "cluster_gateway_ip" {
+  description = "The IP address of the gateway used to contact the cluster nodes"
+  value       = openstack_networking_floatingip_v2.cluster_floating_ip.address
+}
+
+output "cluster_ssh_private_key" {
+  description = "The private key used to deploy the cluster"
+  value = openstack_compute_keypair_v2.cluster_keypair.private_key
+}
+
+output "cluster_nodes" {
+  description = "A list of the nodes in the cluster from which an Ansible inventory will be populated"
+  value       = concat(
+    [
+      {
+        name          = openstack_compute_instance_v2.login.name
+        ip            = openstack_compute_instance_v2.login.network[0].fixed_ip_v4
+        groups        = ["{{ cluster_name }}_login"],
+        facts  = {
+          openstack_project_id = data.openstack_identity_auth_scope_v3.scope.project_id
+        }
+      },
+      {
+        name          = openstack_compute_instance_v2.control.name
+        ip            = openstack_compute_instance_v2.control.network[0].fixed_ip_v4
+        groups        = ["{{ cluster_name }}_control"],
+        facts  = {
+          openstack_project_id = data.openstack_identity_auth_scope_v3.scope.project_id
+        }
+      }
+    ],
+    {% for partition in openhpc_slurm_partitions %}
+    [
+      for compute in openstack_compute_instance_v2.{{ partition.name }}: {
+        name          = compute.name
+        ip            = compute.network[0].fixed_ip_v4
+        groups        = ["{{ cluster_name }}_compute", "{{ cluster_name }}_{{ partition.name }}"],
+        facts  = {
+          openstack_project_id = data.openstack_identity_auth_scope_v3.scope.project_id
+        }
+      }
+    ]{{ ',' if not loop.last }}
+    {% endfor %}
+  )
+}
+
+output "cluster_image" {
+  description = "The id of the image used to build the cluster nodes"
+  value       = "{{ cluster_previous_image | default(cluster_image) }}"
+}

--- a/environments/NL1-CI/cluster_terraform_template/providers.tf.j2
+++ b/environments/NL1-CI/cluster_terraform_template/providers.tf.j2
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.14"
+
+  # We need the OpenStack provider
+  required_providers {
+    openstack = {
+      source = "terraform-provider-openstack/openstack"
+    }
+  }
+}

--- a/environments/NL1-CI/cluster_terraform_template/resources.tf.j2
+++ b/environments/NL1-CI/cluster_terraform_template/resources.tf.j2
@@ -1,0 +1,270 @@
+#####
+##### The identity scope we are operating in
+##### Used to output the OpenStack project ID as a fact for provisioned hosts
+#####
+data "openstack_identity_auth_scope_v3" "scope" {
+  name = "{{ cluster_name }}"
+}
+
+#####
+##### Security groups for the cluster
+#####
+
+# Security group to hold common rules for the cluster
+resource "openstack_networking_secgroup_v2" "secgroup_slurm_cluster" {
+  name                 = "{{ cluster_name }}-secgroup-slurm-cluster"
+  description          = "Rules for the slurm cluster nodes"
+  delete_default_rules = true   # Fully manage with terraform
+}
+
+# Security group to hold specific rules for the login node
+resource "openstack_networking_secgroup_v2" "secgroup_slurm_login" {
+  name                 = "{{ cluster_name }}-secgroup-slurm-login"
+  description          = "Specific rules for the slurm login node"
+  delete_default_rules = true   # Fully manage with terraform
+}
+
+## Allow all egress for all cluster nodes
+resource "openstack_networking_secgroup_rule_v2" "secgroup_slurm_cluster_rule_egress_v4" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup_slurm_cluster.id}"
+}
+
+## Allow all ingress between nodes in the cluster
+resource "openstack_networking_secgroup_rule_v2" "secgroup_slurm_cluster_rule_ingress_internal_v4" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  remote_group_id   = "${openstack_networking_secgroup_v2.secgroup_slurm_cluster.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup_slurm_cluster.id}"
+}
+
+## Allow ingress on port 22 (SSH) from anywhere for the login nodes
+resource "openstack_networking_secgroup_rule_v2" "secgroup_slurm_login_rule_ingress_ssh_v4" {
+  direction = "ingress"
+  ethertype = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup_slurm_login.id}"
+}
+
+## Allow ingress on port 443 (HTTPS) from anywhere for the login nodes
+resource "openstack_networking_secgroup_rule_v2" "secgroup_slurm_login_rule_ingress_https_v4" {
+  direction = "ingress"
+  ethertype = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 443
+  port_range_max    = 443
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup_slurm_login.id}"
+}
+
+## Allow ingress on port 80 (HTTP) from anywhere for the login nodes
+resource "openstack_networking_secgroup_rule_v2" "secgroup_slurm_login_rule_ingress_http_v4" {
+  direction = "ingress"
+  ethertype = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 80
+  port_range_max    = 80
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup_slurm_login.id}"
+}
+
+#####
+##### Volumes
+#####
+resource "openstack_blockstorage_volume_v3" "state" {
+    name = "{{ cluster_name }}-state"
+    description = "State for control node"
+    size = "{{ state_volume_size }}"
+}
+
+resource "openstack_blockstorage_volume_v3" "home" {
+    name = "{{ cluster_name }}-home"
+    description = "Home for control node"
+    size = "{{ home_volume_size }}"
+    {% if use_home_volume_type_fast is defined and use_home_volume_type_fast %}
+    {% if home_volume_type_fast is defined %}
+    volume_type = "{{ home_volume_type_fast }}"
+    {% endif %}
+    {% endif %}
+}
+
+#####
+###### Cluster network
+######
+
+data "openstack_networking_network_v2" "cluster_external_network" {
+  name = "{{ cluster_external_network }}"
+}
+
+resource "openstack_networking_network_v2" "cluster_network" {
+  name           = "{{ cluster_name }}-net"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "cluster_subnet" {
+  name       = "{{ cluster_name }}-subnet"
+  network_id = "${openstack_networking_network_v2.cluster_network.id}"
+  cidr       = "{{ cluster_cidr }}"
+  {% if cluster_nameservers %}
+  dns_nameservers = [
+  {% for nameserver in cluster_nameservers %}
+    "{{ nameserver }}"{{ ',' if not loop.last }}
+  {% endfor %}
+  ]
+  {% endif %}
+  ip_version = 4
+}
+
+resource "openstack_networking_router_v2" "cluster_router" {
+  name                = "{{ cluster_name }}-router"
+  admin_state_up      = true
+  external_network_id = "${data.openstack_networking_network_v2.cluster_external_network.id}"
+}
+
+resource "openstack_networking_router_interface_v2" "cluster_router_interface" {
+  router_id = "${openstack_networking_router_v2.cluster_router.id}"
+  subnet_id = "${openstack_networking_subnet_v2.cluster_subnet.id}"
+}
+
+#####
+###### Cluster private key
+######
+
+resource "openstack_compute_keypair_v2" "cluster_keypair" {
+  name = "{{ cluster_name }}-deploy-key"
+}
+
+#####
+##### Cluster nodes
+#####
+
+{# build list of all ssh keys we need to inject  #}
+{% set auth_keys_list = ["\"${openstack_compute_keypair_v2.cluster_keypair.public_key}\""] + cluster_user_ssh_public_keys | default([cluster_user_ssh_public_key]) %}
+
+resource "openstack_compute_instance_v2" "login" {
+  name      = "{{ cluster_name }}-login-0"
+  image_id  = "{{ cluster_previous_image | default(cluster_image) }}"
+  {% if login_flavor_name is defined %}
+  flavor_name = "{{ login_flavor_name }}"
+  {% else %}
+  flavor_id = "{{ login_flavor }}"
+  {% endif %}
+
+  network {
+    uuid = "${openstack_networking_subnet_v2.cluster_subnet.network_id}"
+  }
+
+  security_groups = [
+    "${openstack_networking_secgroup_v2.secgroup_slurm_cluster.name}",
+    "${openstack_networking_secgroup_v2.secgroup_slurm_login.name}"
+  ]
+  # Use cloud-init to inject the SSH keys
+  user_data = <<-EOF
+    #cloud-config
+    ssh_authorized_keys:
+      - {{ auth_keys_list | join("\n      - ")}}{# don't fix this with to_nice_yaml it will break as it will add extra single quotes around the double quoted TF vars #}
+    
+  EOF
+}
+
+resource "openstack_compute_instance_v2" "control" {
+  name      = "{{ cluster_name }}-control-0"
+  image_id  = "{{ cluster_previous_image | default(cluster_image) }}"
+  {% if control_flavor_name is defined %}
+  flavor_name = "{{ control_flavor_name }}"
+  {% else %}
+  flavor_id = "{{ control_flavor }}"
+  {% endif %}
+
+  network {
+    uuid = "${openstack_networking_subnet_v2.cluster_subnet.network_id}"
+  }
+
+  security_groups = ["${openstack_networking_secgroup_v2.secgroup_slurm_cluster.name}"]
+
+  # root device:
+  block_device {
+      uuid = "{{ cluster_previous_image | default(cluster_image) }}"
+      source_type  = "image"
+      destination_type = "local"
+      boot_index = 0
+      delete_on_termination = true
+  }
+
+  # state volume:
+  block_device {
+      destination_type = "volume"
+      source_type  = "volume"
+      boot_index = -1
+      uuid = openstack_blockstorage_volume_v3.state.id
+  }
+
+  # home volume:
+  block_device {
+      destination_type = "volume"
+      source_type  = "volume"
+      boot_index = -1
+      uuid = openstack_blockstorage_volume_v3.home.id
+  }
+
+  # Use cloud-init to a) inject SSH keys b) configure volumes
+  user_data = <<-EOF
+    #cloud-config
+    ssh_authorized_keys:
+      - {{ auth_keys_list | join("\n      - ")}}{# don't fix this with to_nice_yaml it will break as it will add extra single quotes around the double quoted TF vars #}
+    
+    fs_setup:
+      - label: state
+        filesystem: ext4
+        device: /dev/{{ block_device_prefix }}b
+        partition: auto
+      - label: home
+        filesystem: ext4
+        device: /dev/{{ block_device_prefix }}c
+        partition: auto
+    mounts:
+        - [LABEL=state, /var/lib/state, auto, "x-systemd.required-by=nfs-server.service,x-systemd.before=nfs-server.service"]
+        - [LABEL=home, /exports/home, auto, "x-systemd.required-by=nfs-server.service,x-systemd.before=nfs-server.service"]
+  EOF
+}
+
+{% for partition in openhpc_slurm_partitions %} 
+resource "openstack_compute_instance_v2" "{{ partition.name }}" {
+  count = {{ partition.count }}
+
+  name      = "{{ cluster_name }}-compute-{{ partition.name }}-${count.index}"
+  image_id  = "{{ cluster_previous_image | default(cluster_image) }}"
+  flavor_name = "{{ partition.flavor_name }}"
+
+  network {
+    uuid = "${openstack_networking_subnet_v2.cluster_subnet.network_id}"
+  }
+
+  security_groups = ["${openstack_networking_secgroup_v2.secgroup_slurm_cluster.name}"]
+  # Use cloud-init to inject the SSH keys
+  user_data = <<-EOF
+    #cloud-config
+    ssh_authorized_keys:
+      - {{ auth_keys_list | join("\n      - ")}}{# don't fix this with to_nice_yaml it will break as it will add extra single quotes around the double quoted TF vars #}
+    
+  EOF
+}
+{% endfor %}
+#####
+##### Floating IP association for login node
+#####
+data "openstack_networking_subnet_ids_v2" "ext_subnets" {
+  network_id = "${data.openstack_networking_network_v2.cluster_external_network.id}"
+}
+
+resource "openstack_networking_floatingip_v2" "cluster_floating_ip" {
+  pool       = "${data.openstack_networking_network_v2.cluster_external_network.name}"
+  subnet_ids = "${data.openstack_networking_subnet_ids_v2.ext_subnets.ids}"
+}
+
+resource "openstack_compute_floatingip_associate_v2" "login_floatingip_assoc" {
+  floating_ip = "${openstack_networking_floatingip_v2.cluster_floating_ip.address}"
+  instance_id = "${openstack_compute_instance_v2.login.id}"
+}
+

--- a/environments/eschercloud-image-build/README.md
+++ b/environments/eschercloud-image-build/README.md
@@ -1,0 +1,11 @@
+# Eschercloud image-build
+
+Use this environment to build OpenHPC Slurm images using packer:
+
+```
+source eschercloud-image-build/activate
+cd eschercloud-image-build/packer
+PACKER_LOG=1 packer build -only openstack.openhpc -on-error=ask -var-file=$PKR_VAR_environment_root/builder.pkrvars.hcl openstack.pkr.hcl
+```
+
+Creates `eschercloud-image-build/packer/packer-manifest.json`, containing latest image UUID.

--- a/environments/eschercloud-image-build/activate
+++ b/environments/eschercloud-image-build/activate
@@ -1,0 +1,24 @@
+export APPLIANCES_ENVIRONMENT_ROOT=$(dirname $(realpath ${BASH_SOURCE[0]:-${(%):-%x}}))
+echo "Setting APPLIANCES_ENVIRONMENT_ROOT to $APPLIANCES_ENVIRONMENT_ROOT"
+
+APPLIANCES_ENVIRONMENT_NAME=$(basename $APPLIANCES_ENVIRONMENT_ROOT)
+export PS1="${APPLIANCES_ENVIRONMENT_NAME}/ ${PS1}"
+
+export APPLIANCES_REPO_ROOT=$(realpath "$APPLIANCES_ENVIRONMENT_ROOT/../../vendor/stackhpc/ansible-slurm-appliance")
+echo "Setting APPLIANCES_REPO_ROOT to $APPLIANCES_REPO_ROOT"
+
+export TF_VAR_environment_root=$(realpath "$APPLIANCES_ENVIRONMENT_ROOT")
+echo "Setting TF_VAR_environment_root to $TF_VAR_environment_root"
+
+export PKR_VAR_environment_root=$(realpath "$APPLIANCES_ENVIRONMENT_ROOT")
+echo "Setting PKR_VAR_environment_root to $PKR_VAR_environment_root"
+
+export PKR_VAR_repo_root=$(realpath "$APPLIANCES_REPO_ROOT")
+echo "Setting PKR_VAR_repo_root to $PKR_VAR_repo_root"
+
+if [ -f "$APPLIANCES_ENVIRONMENT_ROOT/ansible.cfg" ]; then
+   export ANSIBLE_CONFIG=$APPLIANCES_ENVIRONMENT_ROOT/ansible.cfg
+   echo "Setting ANSIBLE_CONFIG to $ANSIBLE_CONFIG"
+fi
+
+

--- a/environments/eschercloud-image-build/ansible.cfg
+++ b/environments/eschercloud-image-build/ansible.cfg
@@ -1,0 +1,15 @@
+[defaults]
+any_errors_fatal = True
+stdout_callback = debug
+stderr_callback = debug
+gathering = smart
+forks = 30
+host_key_checking = False
+inventory = ../../vendor/stackhpc/ansible-slurm-appliance/environments/common/inventory,inventory
+collections_path = ../../ansible/collections
+roles_path = ../../vendor/stackhpc/ansible-slurm-appliance/ansible/roles
+filter_plugins = ../../vendor/stackhpc/ansible-slurm-appliance/ansible/filter_plugins
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=240s -o PreferredAuthentications=publickey -o UserKnownHostsFile=/dev/null
+pipelining = True

--- a/environments/eschercloud-image-build/builder.pkrvars.hcl
+++ b/environments/eschercloud-image-build/builder.pkrvars.hcl
@@ -1,0 +1,16 @@
+flavor = "g.2.standard"
+networks = ["53b5d32d-7c32-490c-85c3-7feab2378c07"]
+source_image_name = "Rocky-8-GenericCloud-Base-8.7-20230215.0"
+fatimage_source_image_name = "Rocky-8-GenericCloud-Base-8.7-20230215.0"
+floating_ip_network = "Internet"
+security_groups = ["SSH"]
+ssh_keypair_name = ""
+ssh_private_key_file = ""
+use_blockstorage_volume = true
+volume_size = 15
+reuse_ips = true
+metadata = {
+    hw_scsi_model = "virtio-scsi",
+    hw_disk_bus = "scsi",
+    hw_vif_multiqueue_enabled = true
+}

--- a/environments/eschercloud-image-build/packer/ansible-inventory.sh
+++ b/environments/eschercloud-image-build/packer/ansible-inventory.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# NOTE: This allows to make use of the ANSIBLE_CONFIG environment variable
+
+ansible-inventory --list --export

--- a/environments/eschercloud-image-build/packer/compute_extravars.yml
+++ b/environments/eschercloud-image-build/packer/compute_extravars.yml
@@ -1,0 +1,3 @@
+# Used to override anything defined in a concrete environment
+update_enable: false
+openhpc_slurm_partitions: [] # as no compute nodes will be in play, but partition definition might exist in inventory

--- a/environments/eschercloud-image-build/packer/openhpc_extravars.yml
+++ b/environments/eschercloud-image-build/packer/openhpc_extravars.yml
@@ -1,0 +1,1 @@
+update_enable: true

--- a/environments/eschercloud-image-build/packer/openstack.pkr.hcl
+++ b/environments/eschercloud-image-build/packer/openstack.pkr.hcl
@@ -1,0 +1,176 @@
+# Use like:
+#   $ PACKER_LOG=1 packer build --on-error=ask -var-file=$PKR_VAR_environment_root/builder.pkrvars.hcl openstack.pkr.hcl
+
+packer {
+  required_plugins {
+    git = {
+      version = ">= 0.3.2"
+      source = "github.com/ethanmdavidson/git"
+    }
+  }
+}
+
+data "git-commit" "cwd-head" { }
+
+locals {
+    git_commit = data.git-commit.cwd-head.hash
+    timestamp = formatdate("YYMMDD-hhmm", timestamp())
+}
+
+# Path pointing to root of repository - automatically set by environment variable PKR_VAR_repo_root
+variable "repo_root" {
+  type = string
+}
+
+# Path pointing to environment directory - automatically set by environment variable PKR_VAR_environment_root
+variable "environment_root" {
+  type = string
+}
+
+variable "networks" {
+  type = list(string)
+}
+
+variable "source_image_name" {
+  type = string
+}
+
+variable "fatimage_source_image_name" {
+  type = string
+  default = "Rocky-8-GenericCloud-Base-8.7-20230215.0"
+}
+
+variable "flavor" {
+  type = string
+}
+
+variable "ssh_username" {
+  type = string
+  default = "rocky"
+}
+
+variable "ssh_private_key_file" {
+  type = string
+  default = "~/.ssh/id_rsa"
+}
+
+variable "ssh_keypair_name" {
+  type = string
+}
+
+variable "security_groups" {
+  type = list(string)
+  default = []
+}
+
+variable "image_visibility" {
+  type = string
+  default = "private"
+}
+
+variable "ssh_bastion_host" {
+  type = string
+  default = ""
+}
+
+variable "ssh_bastion_username" {
+  type = string
+  default = ""
+}
+
+variable "ssh_bastion_private_key_file" {
+  type = string
+  default = "~/.ssh/id_rsa"
+}
+
+variable "use_blockstorage_volume" {
+  type = bool
+  default = true
+}
+
+variable "volume_size" {
+  type = number
+  default = 15
+}
+
+variable "floating_ip_network" {
+  type = string
+  default = ""
+}
+
+variable "reuse_ips" {
+  type = bool
+  default = false
+}
+
+variable "metadata" {
+  type = map(string)
+  default = {}
+}
+
+
+source "openstack" "openhpc" {
+  flavor = "${var.flavor}"
+  networks = "${var.networks}"
+  ssh_username = "${var.ssh_username}"
+  ssh_timeout = "20m"
+  ssh_private_key_file = "${var.ssh_private_key_file}" # TODO: doc same requirements as for qemu build?
+  ssh_keypair_name = "${var.ssh_keypair_name}" # TODO: doc this
+  ssh_bastion_host = "${var.ssh_bastion_host}"
+  ssh_bastion_username = "${var.ssh_bastion_username}"
+  ssh_bastion_private_key_file = "${var.ssh_bastion_private_key_file}"
+  security_groups = "${var.security_groups}"
+  image_visibility = "${var.image_visibility}"
+  ssh_clear_authorized_keys = true
+  use_blockstorage_volume = "${var.use_blockstorage_volume}"
+  volume_size = "${var.volume_size}"
+  floating_ip_network = "${var.floating_ip_network}"
+  reuse_ips = "${var.reuse_ips}"
+  metadata = "${var.metadata}"
+}
+
+# NB: build names, split on "-", are used to determine groups to add build to, so could build for a compute gpu group using e.g. `compute-gpu`.
+build {
+  source "source.openstack.openhpc" {
+    name = "compute"
+    source_image_name = "${var.source_image_name}" # NB: must already exist in OpenStack
+    image_name = "ohpc-${source.name}-${local.timestamp}-${substr(local.git_commit, 0, 8)}.qcow2" # also provides a unique legal instance hostname (in case of parallel packer builds)
+    
+  }
+
+  provisioner "ansible" {
+    playbook_file = "${var.repo_root}/ansible/site.yml"
+    groups = concat(["builder"], split("-", "${source.name}"))
+    keep_inventory_file = true # for debugging
+    use_proxy = false # see https://www.packer.io/docs/provisioners/ansible#troubleshooting
+    extra_arguments = ["--limit", "builder", "-i", "${var.repo_root}/packer/ansible-inventory.sh", "-v", "-e", "@${var.repo_root}/packer/${source.name}_extravars.yml"]
+  }
+
+  post-processor "manifest" {
+    custom_data  = {
+      source = "${source.name}"
+    }
+  }
+}
+
+# The "fat" image build with all binaries:
+build {
+  source "source.openstack.openhpc" {
+    source_image_name = "${var.fatimage_source_image_name}" # NB: must already exist in OpenStack
+    image_name = "${source.name}-${local.timestamp}-${substr(local.git_commit, 0, 8)}" # similar to name from slurm_image_builder
+  }
+
+  provisioner "ansible" {
+    playbook_file = "${var.repo_root}/ansible/fatimage.yml"
+    groups = ["builder", "control", "compute"]
+    keep_inventory_file = true # for debugging
+    use_proxy = false # see https://www.packer.io/docs/provisioners/ansible#troubleshooting
+    extra_arguments = ["--limit", "builder", "-i", "${var.repo_root}/packer/ansible-inventory.sh", "-v", "-e", "@${var.repo_root}/packer/${source.name}_extravars.yml"]
+  }
+
+  post-processor "manifest" {
+    custom_data  = {
+      source = "${source.name}"
+    }
+  }
+}

--- a/group_vars/basic_users.yml
+++ b/group_vars/basic_users.yml
@@ -3,4 +3,4 @@ basic_users_users:
     # Hash the password with a salt that is different for each host
     password: "{{ vault_hpc_user_password | password_hash('sha512', 65534 | random(seed=inventory_hostname) | string) }}"
     uid: 1005
-    public_key: "{{ cluster_user_ssh_public_key }}"
+    public_keys: "{{ cluster_user_ssh_public_keys | default([]) }}"

--- a/group_vars/basic_users.yml
+++ b/group_vars/basic_users.yml
@@ -1,6 +1,6 @@
 basic_users_users:
-  - name: azimuth
+  - name: hpc
     # Hash the password with a salt that is different for each host
-    password: "{{ vault_azimuth_user_password | password_hash('sha512', 65534 | random(seed=inventory_hostname) | string) }}"
+    password: "{{ vault_hpc_user_password | password_hash('sha512', 65534 | random(seed=inventory_hostname) | string) }}"
     uid: 1005
     public_key: "{{ cluster_user_ssh_public_key }}"

--- a/group_vars/cluster.yml
+++ b/group_vars/cluster.yml
@@ -3,7 +3,7 @@
 appliances_repository_root: "{{ playbook_dir }}/../"
 
 # Read the secrets from the Ansible local facts on the control host
-vault_azimuth_user_password: "{{ hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_azimuth_user_password }}"
+vault_hpc_user_password: "{{ hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_hpc_user_password }}"
 vault_grafana_admin_password: "{{ hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_grafana_admin_password }}"
 vault_elasticsearch_admin_password: "{{ hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_elasticsearch_admin_password }}"
 vault_elasticsearch_kibana_password: "{{ hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_elasticsearch_kibana_password }}"

--- a/group_vars/openhpc.yml
+++ b/group_vars/openhpc.yml
@@ -1,1 +1,9 @@
 openhpc_cluster_name: "{{ cluster_name }}"
+
+# Provision a single "standard" compute partition using the supplied
+# node count and flavor
+openhpc_slurm_partitions:
+  - name: "standard"
+    count: "{{ compute_count }}"
+    flavor_name: "{{ compute_flavor }}"
+    default: "YES"

--- a/roles/cluster_infra/tasks/main.yml
+++ b/roles/cluster_infra/tasks/main.yml
@@ -6,7 +6,8 @@
 
 # We need to convert the floating IP id to an address for Terraform
 # if we we have cluster_floating_ip, otherwise assume that we're
-# assigning the FIP in Terraform.
+# assigning the FIP in Terraform and that it will be available in
+# outputs.cluster_gateway_ip.
 - block:
     - name: Look up floating IP
       include_role:
@@ -18,7 +19,6 @@
     - name: Set floating IP address fact
       set_fact:
         cluster_floating_ip_address: "{{ os_floating_ip_info.floating_ip_address }}"
-
   when: cluster_floating_ip is defined
 
 - name: Install Terraform binary
@@ -59,7 +59,17 @@
 
 - name: Template Terraform files into project directory
   template:
-    src: "{{ cluster_terraform_template_dir ~ '/' if cluster_terraform_template_dir is defined else '' }}{{ item }}.j2"
+    src: >-
+      {{ 
+        "{}{}.j2".format(
+          (
+             cluster_terraform_template_dir ~ "/" 
+             if cluster_terraform_template_dir is defined 
+             else ""
+          ),
+          item
+        )
+      }}
     dest: "{{ terraform_project_path }}/{{ item }}"
   loop:
     - outputs.tf

--- a/roles/cluster_infra/tasks/main.yml
+++ b/roles/cluster_infra/tasks/main.yml
@@ -5,16 +5,21 @@
       cluster_upgrade_system_packages: {{ cluster_upgrade_system_packages | default('undefined') }}
 
 # We need to convert the floating IP id to an address for Terraform
-- name: Look up floating IP
-  include_role:
-    name: stackhpc.terraform.infra
-    tasks_from: lookup_floating_ip
-  vars:
-    os_floating_ip_id: "{{ cluster_floating_ip }}"
+# if we we have cluster_floating_ip, otherwise assume that we're
+# assigning the FIP in Terraform.
+- block:
+    - name: Look up floating IP
+      include_role:
+        name: stackhpc.terraform.infra
+        tasks_from: lookup_floating_ip
+      vars:
+        os_floating_ip_id: "{{ cluster_floating_ip }}"
 
-- name: Set floating IP address fact
-  set_fact:
-    cluster_floating_ip_address: "{{ os_floating_ip_info.floating_ip_address }}"
+    - name: Set floating IP address fact
+      set_fact:
+        cluster_floating_ip_address: "{{ os_floating_ip_info.floating_ip_address }}"
+
+  when: cluster_floating_ip is defined
 
 - name: Install Terraform binary
   include_role:
@@ -54,7 +59,7 @@
 
 - name: Template Terraform files into project directory
   template:
-    src: "{{ item }}.j2"
+    src: "{{ cluster_terraform_template_dir ~ '/' if cluster_terraform_template_dir is defined else '' }}{{ item }}.j2"
     dest: "{{ terraform_project_path }}/{{ item }}"
   loop:
     - outputs.tf
@@ -64,6 +69,12 @@
 - name: Provision infrastructure
   include_role:
     name: stackhpc.terraform.infra
+
+- name: Set cluster_floating_ip_address fact
+  set_fact:
+    cluster_floating_ip_address: "{{ hostvars[groups['openstack'][0]].terraform_provision.outputs.cluster_gateway_ip.value }}"
+  when:
+    - terraform_state == "present"
 
 # The hosts provisioned by Terraform are put into a primary group by the role
 # These tasks then add those hosts to additional groups depending on the selected options

--- a/roles/cluster_infra/templates/outputs.tf.j2
+++ b/roles/cluster_infra/templates/outputs.tf.j2
@@ -24,16 +24,18 @@ output "cluster_nodes" {
         }
       }
     ],
+    {% for partition in openhpc_slurm_partitions %}
     [
-      for compute in openstack_compute_instance_v2.compute: {
+      for compute in openstack_compute_instance_v2.{{ partition.name }}: {
         name          = compute.name
         ip            = compute.network[0].fixed_ip_v4
-        groups        = ["{{ cluster_name }}_compute"],
+        groups        = ["{{ cluster_name }}_compute", "{{ cluster_name }}_{{ partition.name }}"],
         facts  = {
           openstack_project_id = data.openstack_identity_auth_scope_v3.scope.project_id
         }
       }
-    ]
+    ]{{ ',' if not loop.last }}
+    {% endfor %}
   )
 }
 

--- a/roles/cluster_infra/templates/resources.tf.j2
+++ b/roles/cluster_infra/templates/resources.tf.j2
@@ -179,16 +179,18 @@ resource "openstack_compute_instance_v2" "control" {
   EOF
 }
 
-resource "openstack_compute_instance_v2" "compute" {
-  count = {{ compute_count }}
+{% for partition in openhpc_slurm_partitions %}
+resource "openstack_compute_instance_v2" "{{ partition.name }}" {
+  count = {{ partition.count }}
 
-  name      = "{{ cluster_name }}-compute-${count.index}"
+  name      = "{{ cluster_name }}-compute-{{ partition.name }}-${count.index}"
   image_id  = "{{ cluster_previous_image | default(cluster_image) }}"
-  flavor_id = "{{ compute_flavor }}"
+  flavor_name = "{{ partition.flavor_name }}"
 
   network {
     name = "{{ cluster_network }}"
   }
+
   security_groups = ["${openstack_networking_secgroup_v2.secgroup_slurm_cluster.name}"]
   # Use cloud-init to inject the SSH keys
   user_data = <<-EOF
@@ -198,6 +200,7 @@ resource "openstack_compute_instance_v2" "compute" {
       - {{ cluster_user_ssh_public_key }}
   EOF
 }
+{% endfor %}
 
 #####
 ##### Floating IP association for login node

--- a/roles/persist_openhpc_secrets/templates/openhpc_secrets.fact
+++ b/roles/persist_openhpc_secrets/templates/openhpc_secrets.fact
@@ -1,5 +1,5 @@
 {
-  "vault_azimuth_user_password": "{{ lookup('password', '/dev/null') }}",
+  "vault_hpc_user_password": "{{ lookup('password', '/dev/null') }}",
   "vault_grafana_admin_password": "{{ lookup('password', '/dev/null') }}",
   "vault_elasticsearch_admin_password": "{{ lookup('password', '/dev/null') }}",
   "vault_elasticsearch_kibana_password": "{{ lookup('password', '/dev/null') }}",

--- a/slurm-infra.yml
+++ b/slurm-infra.yml
@@ -114,7 +114,7 @@
         zenith_proxy_mitm_enabled: yes
         zenith_proxy_mitm_auth_inject: basic
         zenith_proxy_mitm_auth_basic_username: azimuth
-        zenith_proxy_mitm_auth_basic_password: "{{ vault_azimuth_user_password }}"
+        zenith_proxy_mitm_auth_basic_password: "{{ vault_hpc_user_password }}"
       when: zenith_subdomain_ood is defined
 
 - import_playbook: vendor/stackhpc/ansible-slurm-appliance/ansible/adhoc/hpctests.yml
@@ -123,6 +123,8 @@
 - hosts: localhost
   tasks:
     - debug: var=outputs
+      when:
+        - cluster_state is not defined or cluster_state == 'present'
       vars:
         # Ansible has a fit when there are two 'hostvars' evaluations in a resolution chain,
         # so we have to repeat logic here unfortunately
@@ -132,7 +134,7 @@
               combine(
                 {
                   "openondemand_url": "https://" ~ (hostvars[groups['openstack'][0]].cluster_floating_ip_address | replace('.', '-')) ~ ".sslip.io",
-                  "azimuth_user_password": hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_azimuth_user_password
+                  "hpc_user_password": hostvars[groups['control'][0]].ansible_local.openhpc_secrets.vault_hpc_user_password
                 }
                 if zenith_fqdn_ood is not defined
                 else {}


### PR DESCRIPTION
Adds two "environments", one solely for running Packer to create an openhpc image, and the second designed to take the output from the build environment and deploy a Slurm cluster for testing.

Each has a README with brief instructions for how to use it.